### PR TITLE
Add Dockerfile.dev for docker build support

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM golang:1.11-alpine3.8
+
+ENV APP_HOME=/home/rangda
+
+COPY . $APP_HOME
+
+WORKDIR $APP_HOME
+
+RUN apk update && apk add git gcc musl-dev make
+
+RUN go mod download
+RUN go mod verify
+RUN make build
+
+EXPOSE 8080
+
+ENTRYPOINT ["bin/app"]


### PR DESCRIPTION
Added Dockerfile.dev to integrate rangda into workbench and also be able to use docker build . without compiling project beforehand